### PR TITLE
Ask user for extension type

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,20 @@ Handy tool when you write down some text using vscode offen, and do not want to 
 1. Create a tmp file with a shortcut.
 
 ## Extension Settings
+
 This extension contributes the following settings:
 
 * `vsc.tmp.deleteOnExit`: removes the created files when vscode exits, default false
 * `vsc.tmp.tmpDir`: where the temporary files will be created, default the system temp dir
+* `vsc.tmp.file.defaultExtension`: Default file extension type for the prompt
 
-## Known Issues
+## Extension Commands
 
-## Release Notes
+All commands are available by opening the Command Palette (`Command+Shift+P` on macOS and `Ctrl+Shift+P` on Windows/Linux) and typing in one of the following Command Name:
 
+| Command Name            | Command ID                 | Description                                          |
+| ----------------------- | -------------------------- | ---------------------------------------------------- |
+| `Vsc-tmp: Create`       | `nvsc.tmp.file.create`     | create a temporary file                              |
+| `Vsc-tmp: Open Created` | `vsc.tmp.file.openCreated` | open a temporary file created in the current session |
 
-
+By default, the extension does not provide any shortcut. But you can assign each command to one. (see [Key Bindings for Visual Studio Code](https://code.visualstudio.com/docs/getstarted/keybindings) for more information).

--- a/package.json
+++ b/package.json
@@ -46,11 +46,13 @@
     "commands": [
       {
         "command": "vsc.tmp.file.create",
-        "title": "Create a temp file"
+        "title": "Create a temp file",
+        "category": "Create temp"
       },
       {
         "command": "vsc.tmp.file.openCreated",
-        "title": "Open a recently created temp file"
+        "title": "Open a recently created temp file",
+        "category": "Create temp"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:vsc.tmp.file.create"
+    "onCommand:vsc.tmp.file.create",
+    "onCommand:vsc.tmp.file.openCreated"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -46,6 +47,10 @@
       {
         "command": "vsc.tmp.file.create",
         "title": "Create a temp file"
+      },
+      {
+        "command": "vsc.tmp.file.openCreated",
+        "title": "Open a recently created temp file"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
       {
         "command": "vsc.tmp.file.create",
         "title": "Create a temp file",
-        "category": "Create temp"
+        "category": "Vsc-tmp"
       },
       {
         "command": "vsc.tmp.file.openCreated",
         "title": "Open a recently created temp file",
-        "category": "Create temp"
+        "category": "Vsc-tmp"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
           "default": false,
           "description": "Delete created temporary files when vscode exits."
         },
+        "vsc.tmp.file.defaultExtension": {
+          "type": "string",
+          "default": "tmp",
+          "description": "Default file extension type for the prompt"
+        },
         "vsc.tmp.tmpDir": {
           "type": "string",
           "default": null,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ export function activate(context: vscode.ExtensionContext) {
     // The command has been defined in the package.json file
     // Now provide the implementation of the command with  registerCommand
     // The commandId parameter must match the command field in package.json
-    let disposable = vscode.commands.registerCommand('vsc.tmp.file.create', () => {
+    let disposable = vscode.commands.registerCommand('vsc.tmp.file.create', async () => {
         // The code you place here will be executed every time your command is executed
         const tempdir = resolvePath(
             vscode.workspace
@@ -39,7 +39,12 @@ export function activate(context: vscode.ExtensionContext) {
             return `${current.getFullYear()}-${current.getMonth() + 1}-${current.getDate()} ${current.getHours()}_${current.getMinutes()}_${current.getSeconds()}_${current.getMilliseconds()}`;
         }
 
-        const filepath = `${tempdir}${Path.sep}tmp_${currentTimeString()}.tmp`;
+        const fileExtension = await vscode.window.showInputBox({
+            prompt: "File extension type",
+            value: "tmp",
+        });
+
+        const filepath = `${tempdir}${Path.sep}tmp_${currentTimeString()}.${fileExtension}`;
         fs.writeFile(filepath, '', _ => { });
         created_files.push(filepath);
         vscode.workspace

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,10 +29,8 @@ export function activate(context: vscode.ExtensionContext) {
     // The commandId parameter must match the command field in package.json
     let disposable = vscode.commands.registerCommand('vsc.tmp.file.create', async () => {
         // The code you place here will be executed every time your command is executed
-        const tempdir = resolvePath(
-            vscode.workspace
-                .getConfiguration('vsc.tmp')
-                .get('tmpDir') || os.tmpdir());
+        const config =  vscode.workspace.getConfiguration('vsc.tmp');
+        const tempdir = resolvePath(config.get('tmpDir') || os.tmpdir());
 
         function currentTimeString(): string {
             const current = new Date();
@@ -41,7 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
 
         const fileExtension = await vscode.window.showInputBox({
             prompt: "File extension type",
-            value: "tmp",
+            value: config.get('file.defaultExtension'),
         });
 
         const filepath = `${tempdir}${Path.sep}tmp_${currentTimeString()}.${fileExtension}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
 
         const fileExtension = await vscode.window.showInputBox({
             prompt: "File extension type",
-            value: config.get('file.defaultExtension'),
+            value: config.get('file.defaultExtension') || "tmp",
         });
 
         const filepath = `${tempdir}${Path.sep}tmp_${currentTimeString()}.${fileExtension}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,13 @@ export function activate(context: vscode.ExtensionContext) {
     // });
     // context.subscriptions.push(onclose);
     context.subscriptions.push(disposable);
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand("vsc.tmp.file.openCreated", async () => {
+            const filepath = await vscode.window.showQuickPick(created_files);
+            vscode.workspace.openTextDocument(filepath).then(vscode.window.showTextDocument)
+        })
+    );
 }
 
 


### PR DESCRIPTION
Hi There. 👋

I have added some new features and updated the readme.

- Custom extension type when creating a temp file (mainly to test random code).
- Open recently created temp files.
- Allow the user to have a default extension type for the input prompt based on a new setting. 

We can add a setting to skip the prompt if you feel it should be more direct.

![preview](https://user-images.githubusercontent.com/28490646/199270820-0b38a10f-b76d-405e-9e2a-c9f61a10c92a.gif)
